### PR TITLE
fixing one word inconsistent label issue

### DIFF
--- a/slate/data.py
+++ b/slate/data.py
@@ -628,9 +628,9 @@ class Item(object):
         if len(self.spans) == 1:
             spans = str(self.spans[0])
             if self.spans[0].start == self.spans[0].end:
-                spans = str(self.spans[0].start)
+                spans = f"({str(self.spans[0].start)}, {str(self.spans[0].start)})"
                 if len(self.spans[0].start) == 1:
-                    spans = str(self.spans[0].start[0])
+                    spans = f"({str(self.spans[0].start[0])}, {str(self.spans[0].start[0])})"
         elif len(self.spans) > 1:
             all_single = True
             for s in self.spans:


### PR DESCRIPTION
For example:

The University of Sydney

I want to label 'The' as 'a' label
The previous output is:
(0, 0) - label:a

But it should be 
((0, 0), (0, 0)) - label:a